### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = function vitePluginVuePugIndentFix() {
     name: 'vite-plugin-vue-pug-indent-fix',
     transform(src, id) {
       if(/\.(vue)/.test(id)) {
-        if(src.startsWith("<template")) { // Vue3 setup component
+        if(src.includes("<template")) { // Vue3 setup component
           const contentTemp = src.match(/<template(?:.+?)>(.*?)<\/template>/s)
           let content = contentTemp && contentTemp[1]
           const oldContent = content


### PR DESCRIPTION
Allow template block in other than first position.

Vite won't build projects if the <template> block  is not right at the beginning of the file.
This happens because the code says "src.startsWith". 
For some reason this is  only a problem during build, not during dev. 

This patch changes the code to "src.includes" and then everything works. 
